### PR TITLE
Generic transaction

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -23,5 +23,5 @@ neon = "0.4.0"
 serde = "1.0.106"
 serde_derive = "1.0.106"
 serde_json = "1.0.52"
-dgraph-tonic = { git = "https://github.com/xanthous-tech/dgraph-tonic", branch = "expose-traits", features = ["sync"] }
+dgraph-tonic = { version = "0.5", features = ["sync"] }
 tokio = { version = "0.2", features = ["macros"] }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -6,7 +6,7 @@ use tasks::QueryWithVarsTask;
 use neon::prelude::*;
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Mutex};
 
 use dgraph_tonic::sync::Client;
 
@@ -59,7 +59,7 @@ declare_types! {
       // let value: Value = serde_json::from_str(json_str).unwrap_or_default();
 
       let task = QueryWithVarsTask {
-        txn: Arc::new(Mutex::new(txn)),
+        txn: Mutex::new(txn),
         query: query,
         vars: vars,
       };

--- a/native/src/tasks/query_with_vars.rs
+++ b/native/src/tasks/query_with_vars.rs
@@ -1,6 +1,5 @@
-use std::str::from_utf8;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Mutex};
 
 use neon::prelude::*;
 use serde_json::Value;
@@ -11,7 +10,7 @@ use dgraph_tonic::{DgraphError};
 use dgraph_tonic::sync::{Query};
 
 pub struct QueryWithVarsTask<Q: Query> {
-  pub txn: Arc<Mutex<Q>>,
+  pub txn: Mutex<Q>,
   pub query: String,
   pub vars: HashMap<String, String>,
 }

--- a/native/src/tasks/query_with_vars.rs
+++ b/native/src/tasks/query_with_vars.rs
@@ -24,8 +24,7 @@ impl<Q: 'static + Query> Task for QueryWithVarsTask<Q> {
   fn perform(&self) -> Result<Self::Output, Self::Error> {
     let response = self.txn.lock().unwrap().query_with_vars(self.query.clone(), self.vars.clone())?;
 
-    let json_str = from_utf8(&response.json).unwrap_or_default();
-    let value: Value = serde_json::from_str(json_str).unwrap_or_default();
+    let value: Value = response.try_into_owned().unwrap_or_default();
 
     Ok(value)
   }

--- a/native/src/tasks/query_with_vars.rs
+++ b/native/src/tasks/query_with_vars.rs
@@ -7,16 +7,16 @@ use serde_json::Value;
 
 use crate::utils::convert_value;
 
-use dgraph_tonic::{DgraphError, LazyClient, LazyDefaultChannel};
-use dgraph_tonic::sync::{Query, ReadOnlyTxn};
+use dgraph_tonic::{DgraphError};
+use dgraph_tonic::sync::{Query};
 
-pub struct QueryWithVarsTask {
-  pub txn: Arc<Mutex<ReadOnlyTxn<LazyClient<LazyDefaultChannel>>>>,
+pub struct QueryWithVarsTask<Q: Query> {
+  pub txn: Arc<Mutex<Q>>,
   pub query: String,
   pub vars: HashMap<String, String>,
 }
 
-impl Task for QueryWithVarsTask {
+impl<Q: 'static + Query> Task for QueryWithVarsTask<Q> {
   type Output = Value;
   type Error = DgraphError;
   type JsEvent = JsValue;


### PR DESCRIPTION
Hey,

I suggest to use generic parameters for transaction variables in task, because you do not not if user of native client will use `http` channel or `tls` channel any channel with `acl` decoration.